### PR TITLE
Replace PNG placeholder with SVG and add HTML escaping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.dist
+.tmp
+*.log
+screenshots
+playwright-report
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-Initial readme - will update later
+# OG Lab
+
+Open Graph Composer & Preview.
+
+## Quick Start
+
+```sh
+pnpm install  # or npm install / yarn
+pnpm dev      # Vite at http://localhost:5173 and server at http://localhost:8787
+```
+
+Open the app, tweak fields, view previews, copy outputs.
+
+For serverless deploy, replace Express with a Worker that exposes the same `/api/scrape` JSON.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+import js from "@eslint/js";
+import ts from "typescript-eslint";
+import reactPlugin from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  reactPlugin.configs.flat?.recommended,
+  reactHooks.configs.recommended,
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: { parser: ts.parser },
+    settings: { react: { version: "detect" } },
+  },
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OG Lab</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "og-lab",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"vite\" \"ts-node server/index.ts\"",
+    "build": "vite build",
+    "preview": "vite preview",
+    "server": "ts-node server/index.ts",
+    "test": "playwright test",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "classnames": "^2.3.2",
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2",
+    "cheerio": "^1.0.0-rc.12"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "ts-node": "^10.9.1",
+    "vite": "^5.1.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/eslint-plugin": "^6.16.0",
+    "@typescript-eslint/parser": "^6.16.0",
+    "playwright": "^1.45.0",
+    "concurrently": "^8.2.0",
+    "@eslint/js": "^8.56.0",
+    "typescript-eslint": "^7.5.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <rect width="100" height="100" rx="20" fill="#2563EB"/>
+  <text x="50" y="55" font-size="45" text-anchor="middle" fill="white">OG</text>
+</svg>

--- a/public/og-placeholder.svg
+++ b/public/og-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#e5e7eb" />
+  <text x="600" y="315" text-anchor="middle" dominant-baseline="middle" fill="#9ca3af" font-family="sans-serif" font-size="48">No Image</text>
+</svg>

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,22 @@
+import express from "express";
+import cors from "cors";
+import { scrapeMetaToConfig } from "./meta";
+
+const app = express();
+app.use(cors());
+
+app.get("/api/health", (_req, res) => res.json({ ok: true }));
+
+app.get("/api/scrape", async (req, res) => {
+  const url = String(req.query.url || "");
+  if (!url) return res.status(400).json({ error: "Missing url" });
+  try {
+    const cfg = await scrapeMetaToConfig(url);
+    res.json(cfg);
+  } catch (e: any) {
+    res.status(500).json({ error: e?.message || "Scrape failed" });
+  }
+});
+
+const PORT = process.env.PORT || 8787;
+app.listen(PORT, () => console.log(`Server on :${PORT}`));

--- a/server/meta.ts
+++ b/server/meta.ts
@@ -1,0 +1,46 @@
+import fetch from "node-fetch";
+import * as cheerio from "cheerio";
+import { OgConfig } from "../src/lib/types";
+
+export async function scrapeMetaToConfig(url: string): Promise<OgConfig> {
+  const resp = await fetch(url, { redirect: "follow" });
+  if (!resp.ok) throw new Error(`Fetch failed: ${resp.status}`);
+  const html = await resp.text();
+  const $ = cheerio.load(html);
+
+  const get = (prop: string) =>
+    $(`meta[property="${prop}"]`).attr("content") ||
+    $(`meta[name="${prop}"]`).attr("content") || "";
+
+  const images = $(`meta[property="og:image"]`)
+    .map((_i, el) => ({ url: $(el).attr("content") || "" }))
+    .get()
+    .filter(x => x.url);
+
+  const config: OgConfig = {
+    title: get("og:title") || $("title").text().trim() || "Untitled",
+    description: get("og:description") || $('meta[name="description"]').attr("content"),
+    url: get("og:url") || url,
+    siteName: get("og:site_name") || new URL(url).hostname.replace(/^www\./, ""),
+    type: get("og:type") || "website",
+    locale: get("og:locale") || "en_US",
+    images: images.length ? images : [],
+    twitterCard: (get("twitter:card") as any) || undefined,
+    twitterSite: get("twitter:site") || undefined,
+    twitterCreator: get("twitter:creator") || undefined,
+  };
+
+  // Attach width/height/alt if present
+  const withDetails = config.images.map(img => {
+    const w = $(`meta[property="og:image:width"]`).attr("content");
+    const h = $(`meta[property="og:image:height"]`).attr("content");
+    const alt = $(`meta[property="og:image:alt"]`).attr("content");
+    return {
+      ...img,
+      width: w ? Number(w) : undefined,
+      height: h ? Number(h) : undefined,
+      alt: alt || undefined,
+    };
+    });
+  return { ...config, images: withDetails };
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { sampleConfig } from "./mocks/sampleConfig";
+import { OgConfig } from "./lib/types";
+import { validateConfig } from "./lib/validators";
+import { scrapeUrl } from "./lib/scrape-client";
+import EditorForm from "./components/EditorForm";
+import PreviewPane from "./components/PreviewPane";
+import WarningsList from "./components/WarningsList";
+import HeadTagOutput from "./components/HeadTagOutput";
+import HtmlSnippetOutput from "./components/HtmlSnippetOutput";
+import JsonOutput from "./components/JsonOutput";
+
+export default function App() {
+  const [config, setConfig] = useState<OgConfig>(sampleConfig);
+  const validation = validateConfig(config);
+
+  const handlePrefill = async () => {
+    const url = window.prompt("URL to scrape?");
+    if (!url) return;
+    const scraped = await scrapeUrl(url);
+    if (scraped) setConfig(scraped);
+    else alert("Scrape failed");
+  };
+
+  return (
+    <div className="min-h-screen p-4 space-y-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">OG Lab</h1>
+        <button
+          onClick={handlePrefill}
+          className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
+        >
+          Prefill from URL
+        </button>
+      </header>
+
+      <WarningsList validation={validation} />
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <EditorForm config={config} onChange={setConfig} />
+        <PreviewPane config={config} />
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-4">
+        <HeadTagOutput config={config} />
+        <HtmlSnippetOutput config={config} />
+        <JsonOutput config={config} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditorForm.tsx
+++ b/src/components/EditorForm.tsx
@@ -1,0 +1,103 @@
+import { OgConfig } from "../lib/types";
+import ImageList from "./ImageList";
+
+export default function EditorForm({
+  config,
+  onChange,
+}: {
+  config: OgConfig;
+  onChange: (cfg: OgConfig) => void;
+}) {
+  const upd = (field: keyof OgConfig, value: any) =>
+    onChange({ ...config, [field]: value });
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <label className="block text-sm font-medium">Title</label>
+        <input
+          className="w-full border rounded px-2 py-1"
+          value={config.title}
+          onChange={e => upd("title", e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Description</label>
+        <textarea
+          className="w-full border rounded px-2 py-1"
+          value={config.description || ""}
+          onChange={e => upd("description", e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">URL</label>
+        <input
+          className="w-full border rounded px-2 py-1"
+          value={config.url}
+          onChange={e => upd("url", e.target.value)}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-sm font-medium">Site Name</label>
+          <input
+            className="w-full border rounded px-2 py-1"
+            value={config.siteName || ""}
+            onChange={e => upd("siteName", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Type</label>
+          <input
+            className="w-full border rounded px-2 py-1"
+            value={config.type || ""}
+            onChange={e => upd("type", e.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Locale</label>
+        <input
+          className="w-full border rounded px-2 py-1"
+          value={config.locale || ""}
+          onChange={e => upd("locale", e.target.value)}
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <label className="block text-sm font-medium">Twitter Card</label>
+          <input
+            className="w-full border rounded px-2 py-1"
+            value={config.twitterCard || ""}
+            onChange={e => upd("twitterCard", e.target.value as any)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Twitter Site</label>
+          <input
+            className="w-full border rounded px-2 py-1"
+            value={config.twitterSite || ""}
+            onChange={e => upd("twitterSite", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Twitter Creator</label>
+          <input
+            className="w-full border rounded px-2 py-1"
+            value={config.twitterCreator || ""}
+            onChange={e => upd("twitterCreator", e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Images</label>
+        <ImageList
+          images={config.images}
+          onChange={imgs => upd("images", imgs)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/HeadTagOutput.tsx
+++ b/src/components/HeadTagOutput.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { OgConfig } from "../lib/types";
+import { generateHead } from "../lib/generateHead";
+import { copyToClipboard } from "../lib/format";
+
+export default function HeadTagOutput({ config }: { config: OgConfig }) {
+  const head = generateHead(config);
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    await copyToClipboard(head);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="border rounded p-2 text-sm">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-semibold">&lt;head&gt; tags</h3>
+        <div className="space-x-2 flex items-center">
+          {copied && <span className="text-green-600 text-xs">Copied</span>}
+          <button onClick={copy} className="px-2 py-1 bg-blue-600 text-white rounded text-xs">
+            Copy
+          </button>
+        </div>
+      </div>
+      <pre className="whitespace-pre-wrap break-all">{head}</pre>
+    </div>
+  );
+}

--- a/src/components/HtmlSnippetOutput.tsx
+++ b/src/components/HtmlSnippetOutput.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { OgConfig } from "../lib/types";
+import { generateMinimalHtml } from "../lib/generateHtml";
+import { copyToClipboard } from "../lib/format";
+
+export default function HtmlSnippetOutput({ config }: { config: OgConfig }) {
+  const html = generateMinimalHtml(config);
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    await copyToClipboard(html);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  const download = () => {
+    const blob = new Blob([html], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "og-sample.html";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <div className="border rounded p-2 text-sm">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-semibold">HTML snippet</h3>
+        <div className="space-x-2 flex items-center">
+          {copied && <span className="text-green-600 text-xs">Copied</span>}
+          <button onClick={copy} className="px-2 py-1 bg-blue-600 text-white rounded text-xs">
+            Copy
+          </button>
+          <button onClick={download} className="px-2 py-1 bg-neutral-200 rounded text-xs">
+            Download
+          </button>
+        </div>
+      </div>
+      <pre className="whitespace-pre-wrap break-all">{html}</pre>
+    </div>
+  );
+}

--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -1,0 +1,57 @@
+import { OgImage } from "../lib/types";
+
+export default function ImageList({
+  images,
+  onChange,
+}: {
+  images: OgImage[];
+  onChange: (imgs: OgImage[]) => void;
+}) {
+  const update = (idx: number, img: OgImage) => {
+    const next = [...images];
+    next[idx] = img;
+    onChange(next);
+  };
+  const remove = (idx: number) => {
+    const next = images.filter((_, i) => i !== idx);
+    onChange(next);
+  };
+  const move = (idx: number, dir: -1 | 1) => {
+    const next = [...images];
+    const target = idx + dir;
+    if (target < 0 || target >= next.length) return;
+    [next[idx], next[target]] = [next[target], next[idx]];
+    onChange(next);
+  };
+  const add = () => onChange([...images, { url: "" }]);
+
+  return (
+    <div className="space-y-2">
+      {images.map((img, i) => (
+        <div key={i} className="flex items-center space-x-2">
+          <input
+            className="flex-1 border rounded px-2 py-1 text-sm"
+            placeholder="Image URL"
+            value={img.url}
+            onChange={e => update(i, { ...img, url: e.target.value })}
+          />
+          <button className="px-2" onClick={() => move(i, -1)}>
+            ↑
+          </button>
+          <button className="px-2" onClick={() => move(i, 1)}>
+            ↓
+          </button>
+          <button className="px-2 text-red-600" onClick={() => remove(i)}>
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        className="text-sm px-2 py-1 rounded bg-green-600 text-white"
+        onClick={add}
+      >
+        Add image
+      </button>
+    </div>
+  );
+}

--- a/src/components/JsonOutput.tsx
+++ b/src/components/JsonOutput.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { OgConfig } from "../lib/types";
+import { copyToClipboard } from "../lib/format";
+
+export default function JsonOutput({ config }: { config: OgConfig }) {
+  const json = JSON.stringify(config, null, 2);
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    await copyToClipboard(json);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  const download = () => {
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "og-config.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <div className="border rounded p-2 text-sm">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-semibold">JSON export</h3>
+        <div className="space-x-2 flex items-center">
+          {copied && <span className="text-green-600 text-xs">Copied</span>}
+          <button onClick={copy} className="px-2 py-1 bg-blue-600 text-white rounded text-xs">
+            Copy
+          </button>
+          <button onClick={download} className="px-2 py-1 bg-neutral-200 rounded text-xs">
+            Download
+          </button>
+        </div>
+      </div>
+      <pre className="whitespace-pre-wrap break-all">{json}</pre>
+    </div>
+  );
+}

--- a/src/components/PlatformPreview.tsx
+++ b/src/components/PlatformPreview.tsx
@@ -1,0 +1,34 @@
+import { OgConfig } from "../lib/types";
+import { PlatformProfile } from "../lib/platformProfiles";
+import { truncate, domainOf } from "../lib/format";
+
+export default function PlatformPreview({
+  config,
+  profile,
+}: {
+  config: OgConfig;
+  profile: PlatformProfile;
+}) {
+  const img = config.images[profile.preferImageIndex || 0];
+  const imageUrl = img?.url || "/og-placeholder.svg";
+  const title = truncate(config.title, profile.maxTitleLen, profile.truncateTitleEllipsis);
+  const desc = truncate(
+    config.description || "",
+    profile.maxDescLen,
+    profile.truncateDescEllipsis
+  );
+  const domain = profile.showDomain ? domainOf(config.url) : "";
+
+  return (
+    <div className="rounded-2xl shadow-sm border bg-white dark:bg-neutral-900 overflow-hidden max-w-md">
+      <div className="relative pb-[52.3%] bg-neutral-200">
+        <img src={imageUrl} alt="preview" className="absolute inset-0 w-full h-full object-cover" />
+      </div>
+      <div className="p-3 space-y-1">
+        {domain && <div className="text-xs uppercase tracking-wide text-neutral-500">{domain}</div>}
+        <div className="font-semibold text-sm">{title}</div>
+        {desc && <div className="text-sm text-neutral-600 dark:text-neutral-300">{desc}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+import { OgConfig } from "../lib/types";
+import { PROFILES } from "../lib/platformProfiles";
+import Tabs from "./Tabs";
+import PlatformPreview from "./PlatformPreview";
+
+export default function PreviewPane({ config }: { config: OgConfig }) {
+  const tabs = Object.values(PROFILES).map(p => ({ id: p.key, label: p.label }));
+  const [active, setActive] = useState(tabs[0].id);
+  const profile = PROFILES[active as keyof typeof PROFILES];
+  return (
+    <div>
+      <Tabs tabs={tabs} active={active} onChange={setActive} />
+      <PlatformPreview config={config} profile={profile} />
+    </div>
+  );
+}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,29 @@
+export type Tab = { id: string; label: string };
+
+export default function Tabs({
+  tabs,
+  active,
+  onChange,
+}: {
+  tabs: Tab[];
+  active: string;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <div className="flex border-b mb-2">
+      {tabs.map(t => (
+        <button
+          key={t.id}
+          className={`px-3 py-1 -mb-px border-b-2 text-sm ${
+            active === t.id
+              ? "border-blue-600 text-blue-600"
+              : "border-transparent text-neutral-500"
+          }`}
+          onClick={() => onChange(t.id)}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/WarningsList.tsx
+++ b/src/components/WarningsList.tsx
@@ -1,0 +1,23 @@
+import { ValidationResult } from "../lib/validators";
+
+export default function WarningsList({
+  validation,
+}: {
+  validation: ValidationResult;
+}) {
+  if (!validation.errors.length && !validation.warnings.length) return null;
+  return (
+    <div className="p-2 border rounded bg-yellow-50 text-sm space-y-1">
+      {validation.errors.map((e, i) => (
+        <div key={"e" + i} className="text-red-700">
+          {e}
+        </div>
+      ))}
+      {validation.warnings.map((w, i) => (
+        <div key={"w" + i} className="text-yellow-700">
+          {w}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100;
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,18 @@
+export const truncate = (s: string, max: number, ellipsis = "…") =>
+  s.length > max ? s.slice(0, Math.max(0, max - ellipsis.length)) + ellipsis : s;
+
+export const domainOf = (href: string): string => {
+  try {
+    return new URL(href).hostname.replace(/^www\./, "");
+  } catch {
+    return href;
+  }
+};
+
+export async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    console.error("copy failed", err);
+  }
+}

--- a/src/lib/generateHead.ts
+++ b/src/lib/generateHead.ts
@@ -1,0 +1,32 @@
+import { OgConfig } from "./types";
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+
+export function generateHead(config: OgConfig): string {
+  const out: string[] = [];
+  out.push(`<meta property="og:title" content="${esc(config.title)}">`);
+  if (config.description)
+    out.push(`<meta property="og:description" content="${esc(config.description)}">`);
+  out.push(`<meta property="og:url" content="${esc(config.url)}">`);
+  out.push(
+    `<meta property="og:type" content="${esc(config.type || "website")}">`
+  );
+  if (config.siteName)
+    out.push(`<meta property="og:site_name" content="${esc(config.siteName)}">`);
+  if (config.locale)
+    out.push(`<meta property="og:locale" content="${esc(config.locale)}">`);
+
+  for (const img of config.images) {
+    out.push(`<meta property="og:image" content="${esc(img.url)}">`);
+    if (img.width) out.push(`<meta property="og:image:width" content="${img.width}">`);
+    if (img.height) out.push(`<meta property="og:image:height" content="${img.height}">`);
+    if (img.alt) out.push(`<meta property="og:image:alt" content="${esc(img.alt)}">`);
+  }
+
+  if (config.twitterCard) out.push(`<meta name="twitter:card" content="${config.twitterCard}">`);
+  if (config.twitterSite) out.push(`<meta name="twitter:site" content="${esc(config.twitterSite)}">`);
+  if (config.twitterCreator) out.push(`<meta name="twitter:creator" content="${esc(config.twitterCreator)}">`);
+
+  return out.join("\n");
+}

--- a/src/lib/generateHtml.ts
+++ b/src/lib/generateHtml.ts
@@ -1,0 +1,32 @@
+import { generateHead } from "./generateHead";
+import { OgConfig } from "./types";
+
+const escapeHtml = (s: string) =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+export function generateMinimalHtml(config: OgConfig): string {
+  const head = generateHead(config);
+  const title = escapeHtml(config.title);
+  const desc = config.description ? escapeHtml(config.description) : "";
+  const url = escapeHtml(config.url);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${title}</title>
+${head}
+</head>
+<body>
+  <main style="font-family: system-ui, sans-serif; padding: 24px;">
+    <h1>${title}</h1>
+    <p>${desc}</p>
+    <p><a href="${url}">${url}</a></p>
+  </main>
+</body>
+</html>`;
+}

--- a/src/lib/platformProfiles.ts
+++ b/src/lib/platformProfiles.ts
@@ -1,0 +1,54 @@
+export type PlatformKey = "whatsapp" | "rcs" | "imessage" | "twitter";
+
+export type PlatformProfile = {
+  key: PlatformKey;
+  label: string;
+  usesTwitterTags?: boolean;
+  preferImageIndex?: number;
+  maxTitleLen: number;
+  maxDescLen: number;
+  imageAspectHint?: "landscape" | "square";
+  showDomain: boolean;
+  truncateTitleEllipsis?: string;
+  truncateDescEllipsis?: string;
+};
+
+export const PROFILES: Record<PlatformKey, PlatformProfile> = {
+  whatsapp: {
+    key: "whatsapp",
+    label: "WhatsApp",
+    maxTitleLen: 90,
+    maxDescLen: 140,
+    preferImageIndex: 0,
+    imageAspectHint: "landscape",
+    showDomain: true,
+  },
+  rcs: {
+    key: "rcs",
+    label: "RCS",
+    maxTitleLen: 70,
+    maxDescLen: 120,
+    preferImageIndex: 0,
+    imageAspectHint: "landscape",
+    showDomain: true,
+  },
+  imessage: {
+    key: "imessage",
+    label: "iMessage",
+    maxTitleLen: 80,
+    maxDescLen: 120,
+    preferImageIndex: 0,
+    imageAspectHint: "landscape",
+    showDomain: true,
+  },
+  twitter: {
+    key: "twitter",
+    label: "X/Twitter",
+    usesTwitterTags: true,
+    maxTitleLen: 70,
+    maxDescLen: 200,
+    preferImageIndex: 0,
+    imageAspectHint: "landscape",
+    showDomain: true,
+  },
+};

--- a/src/lib/scrape-client.ts
+++ b/src/lib/scrape-client.ts
@@ -1,0 +1,7 @@
+import { OgConfig } from "./types";
+
+export async function scrapeUrl(url: string): Promise<OgConfig | null> {
+  const res = await fetch(`/api/scrape?url=${encodeURIComponent(url)}`);
+  if (!res.ok) return null;
+  return (await res.json()) as OgConfig;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,20 @@
+export type OgImage = {
+  url: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+};
+
+export type OgConfig = {
+  title: string;
+  description?: string;
+  url: string;
+  siteName?: string;
+  type?: "website" | "article" | "product" | string;
+  locale?: string;
+  images: OgImage[];
+  // Optional Twitter crosswalk
+  twitterCard?: "summary" | "summary_large_image";
+  twitterSite?: string;     // e.g., @brand
+  twitterCreator?: string;  // e.g., @author
+};

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,42 @@
+import { OgImage, OgConfig } from "./types";
+
+export type ValidationResult = {
+  warnings: string[];
+  errors: string[];
+};
+
+export function validateConfig(config: OgConfig): ValidationResult {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  if (!config.title?.trim()) errors.push("Title is required.");
+  if (!config.url?.trim()) errors.push("URL is required.");
+  try {
+    new URL(config.url);
+  } catch {
+    errors.push("URL is not a valid absolute URL.");
+  }
+
+  if (!config.images?.length) warnings.push("No og:image set. Many platforms show weaker previews.");
+  if (config.images?.length > 4) warnings.push("Multiple images set. Most platforms use only the first.");
+
+  return { warnings, errors };
+}
+
+// Lightweight HEAD check client-side (best-effort). Server should do real checks.
+export async function probeImageHeads(images: OgImage[]): Promise<string[]> {
+  const warnings: string[] = [];
+  await Promise.all(images.map(async img => {
+    try {
+      const res = await fetch(img.url, { method: "HEAD", mode: "no-cors" as RequestMode });
+      // In no-cors mode, cannot read headers reliably; this is placeholder.
+      // A real check should run on the server.
+      if (!img.url.startsWith("https://") && !img.url.startsWith("http://")) {
+        warnings.push(`Image URL not http/https: ${img.url}`);
+      }
+    } catch {
+      warnings.push(`Failed to reach image: ${img.url}`);
+    }
+  }));
+  return warnings;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/mocks/sampleConfig.ts
+++ b/src/mocks/sampleConfig.ts
@@ -1,0 +1,16 @@
+import { OgConfig } from "../lib/types";
+
+export const sampleConfig: OgConfig = {
+  title: "Galactic Coffee: A Better Brew",
+  description: "Single‑origin beans, gentle roast, and free shipping over €25.",
+  url: "https://example.com/coffee",
+  siteName: "Example Coffee",
+  type: "website",
+  locale: "en_US",
+  images: [
+    { url: "/og-placeholder.svg", width: 1200, height: 630, alt: "Cup of coffee on a table" }
+  ],
+  twitterCard: "summary_large_image",
+  twitterSite: "@example",
+  twitterCreator: "@barista",
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}", "./public/**/*"],
+  theme: {
+    extend: {},
+  },
+  darkMode: "media",
+  plugins: [],
+};

--- a/tests/generateHtml.spec.ts
+++ b/tests/generateHtml.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { generateMinimalHtml } from '../src/lib/generateHtml';
+
+test('escapes HTML special chars', () => {
+  const html = generateMinimalHtml({
+    title: '<script>',
+    description: 'Fish & Chips',
+    url: 'https://example.com/?q="test"&x=<x>',
+    images: [],
+  });
+  expect(html).toContain('&lt;script&gt;');
+  expect(html).toContain('Fish &amp; Chips');
+  expect(html).toContain('https://example.com/?q=&quot;test&quot;&amp;x=&lt;x&gt;');
+});

--- a/tests/preview.spec.ts
+++ b/tests/preview.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+const tabs = ["WhatsApp", "RCS", "iMessage", "X/Twitter"];
+
+test.describe("preview cards", () => {
+  test("render and snapshot", async ({ page }) => {
+    await page.goto("http://localhost:5173");
+    for (const tab of tabs) {
+      await page.click(`text=${tab}`);
+      const card = page.locator(".rounded-2xl").first();
+      await expect(card).toContainText("Galactic Coffee");
+      await card.screenshot({ path: `screenshots/${tab}.png` });
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "baseUrl": "."
+  },
+  "include": ["src", "server"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8787",
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- swap binary PNG placeholder for inline SVG and update references
- handle clipboard errors gracefully
- escape user-provided HTML when generating minimal pages and test escaping
- declare missing ESLint dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cae6769948320868eb99af8d772c5